### PR TITLE
Correct navbar links while within /blog

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -16,10 +16,10 @@
  </nav>
  <nav class="col  main">
   <ul class="nav clearfix">
-   <li><a href="../#top" title = "Top">Home</a></li>
-   <li><a href="../#get-involved" title = "Get Involved">Get Involved</a></li>
-   <li><a href="../#speakers" title = "Speakers">People &amp; Events</a></li>
-   <li><a href="../#sponsors" title = "Sponsors">Sponsors</a></li>
+   <li><a href="/#top" title = "Top">Home</a></li>
+   <li><a href="/#get-involved" title = "Get Involved">Get Involved</a></li>
+   <li><a href="/#speakers" title = "Speakers">People &amp; Events</a></li>
+   <li><a href="/#sponsors" title = "Sponsors">Sponsors</a></li>
    <li><a href="/blog/index.html" title = "Blog">Blog</a></li>
  </ul>
 </nav>


### PR DESCRIPTION
Thank you for mhprompt :purple_heart: 

What this PR changes: 

Within /blog, the navbar links previously went to /YYYY/MM/#page

Possible related issues: 

There's another issue where at the moment, /blog links go to /YYYY/DD/MM not /blog/YYYY/MM/DD, but I'm not changing that as not to 404 all the links out in the wild. 

Additionally, http://mhprompt.org/2015/10/05/our-indiegogo-story.html currently renders without markdown parsing, but this doesn't happen when running locally. 
