### PR TITLE
Fix broken modernizr filename

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,29 +2,20 @@
 <!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
 <!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
 <!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!-->
-<html class="no-js">
-  <!--<![endif]-->
-  <head>
-    <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-    <title>
-      {{ page.title | Prompt - Mental health in the technology industry }}
-    </title>
-    <meta name="description" content="" />
-    <meta name="viewport" content="width=device-width" />
-    <link
-      href="http://fonts.googleapis.com/css?family=Lato:200,400,700,900"
-      rel="stylesheet"
-      type="text/css"
-    />
+<!--[if gt IE 8]><!--> <html class="no-js"> <!--<![endif]-->
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <title>{{ page.title | Prompt - Mental health in the technology industry }}</title>
+  <meta name="description" content="">
+  <meta name="viewport" content="width=device-width">
+  <link href='http://fonts.googleapis.com/css?family=Lato:200,400,700,900' rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
-    <script src='{{ "/js/vendor/modernizr-2.6.2.min.js" | prepend: site.baseurl }}'></script>
-    <script src="http://maps.googleapis.com/maps/api/js?sensor=false"></script>
-    <script src='{{ "/js/vendor/jquery-1.9.1.min.js" | prepend: site.baseurl }}'></script>
-    <script src='{{ "/js/plugins.js" | prepend: site.baseurl }}'></script>
-    <script src='{{ "/js/main.js" | prepend: site.baseurl }}'></script>
-  </head>
-  <body data-spy="scroll" data-target=".main" data-offset="50"></body>
-</html>
+  <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
+  <script src='{{ "/js/vendor/modernizr-2.6.2.min.js" | prepend: site.baseurl }}'></script>
+  <script src="http://maps.googleapis.com/maps/api/js?sensor=false"></script>
+  <script src='{{ "/js/vendor/jquery-1.9.1.min.js" | prepend: site.baseurl }}'></script>
+  <script src='{{ "/js/plugins.js" | prepend: site.baseurl }}'></script>
+  <script src='{{ "/js/main.js" | prepend: site.baseurl }}'></script>
+</head>
+<body  data-spy="scroll" data-target=".main" data-offset="50">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,20 +2,29 @@
 <!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
 <!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
 <!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html class="no-js"> <!--<![endif]-->
-<head>
-  <meta charset="utf-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-  <title>{{ page.title | Prompt - Mental health in the technology industry }}</title>
-  <meta name="description" content="">
-  <meta name="viewport" content="width=device-width">
-  <link href='http://fonts.googleapis.com/css?family=Lato:200,400,700,900' rel='stylesheet' type='text/css'>
+<!--[if gt IE 8]><!-->
+<html class="no-js">
+  <!--<![endif]-->
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <title>
+      {{ page.title | Prompt - Mental health in the technology industry }}
+    </title>
+    <meta name="description" content="" />
+    <meta name="viewport" content="width=device-width" />
+    <link
+      href="http://fonts.googleapis.com/css?family=Lato:200,400,700,900"
+      rel="stylesheet"
+      type="text/css"
+    />
 
-  <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
-  <script src='{{ "/js/vendor/modernizr-2.6.2.min" | prepend: site.baseurl }}'></script>
-  <script src="http://maps.googleapis.com/maps/api/js?sensor=false"></script>
-  <script src='{{ "/js/vendor/jquery-1.9.1.min.js" | prepend: site.baseurl }}'></script>
-  <script src='{{ "/js/plugins.js" | prepend: site.baseurl }}'></script>
-  <script src='{{ "/js/main.js" | prepend: site.baseurl }}'></script>
-</head>
-<body  data-spy="scroll" data-target=".main" data-offset="50">
+    <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
+    <script src='{{ "/js/vendor/modernizr-2.6.2.min.js" | prepend: site.baseurl }}'></script>
+    <script src="http://maps.googleapis.com/maps/api/js?sensor=false"></script>
+    <script src='{{ "/js/vendor/jquery-1.9.1.min.js" | prepend: site.baseurl }}'></script>
+    <script src='{{ "/js/plugins.js" | prepend: site.baseurl }}'></script>
+    <script src='{{ "/js/main.js" | prepend: site.baseurl }}'></script>
+  </head>
+  <body data-spy="scroll" data-target=".main" data-offset="50"></body>
+</html>


### PR DESCRIPTION
I noticed a 404 requesting `http://mhprompt.org/js/vendor/modernizr-2.6.2.min`. I've corrected the filename, adding `.js` at the end.